### PR TITLE
camera: Only link and use vendor.qti.hardware.camera.device if specified

### DIFF
--- a/camera/cameraserver/Android.mk
+++ b/camera/cameraserver/Android.mk
@@ -30,8 +30,13 @@ LOCAL_SHARED_LIBRARIES := \
 	android.hardware.camera.common@1.0 \
 	android.hardware.camera.provider@2.4 \
 	android.hardware.camera.device@1.0 \
-	android.hardware.camera.device@3.2 \
+	android.hardware.camera.device@3.2
+
+ifeq ($(TARGET_USES_QTI_CAMERA_DEVICE), true)
+LOCAL_CFLAGS += -DQTI_CAMERA_DEVICE
+LOCAL_SHARED_LIBRARIES += \
 	vendor.qti.hardware.camera.device@1.0
+endif
 
 LOCAL_MODULE:= cameraserver
 LOCAL_32_BIT_ONLY := true

--- a/services/camera/libcameraservice/Android.mk
+++ b/services/camera/libcameraservice/Android.mk
@@ -77,9 +77,14 @@ LOCAL_SHARED_LIBRARIES:= \
     android.hardware.camera.common@1.0 \
     android.hardware.camera.provider@2.4 \
     android.hardware.camera.device@1.0 \
-    vendor.qti.hardware.camera.device@1.0 \
     android.hardware.camera.device@3.2 \
     android.hardware.camera.device@3.3
+
+ifeq ($(TARGET_USES_QTI_CAMERA_DEVICE), true)
+LOCAL_CFLAGS += -DQTI_CAMERA_DEVICE
+LOCAL_SHARED_LIBRARIES += \
+	vendor.qti.hardware.camera.device@1.0
+endif
 
 LOCAL_EXPORT_SHARED_LIBRARY_HEADERS := libbinder libcamera_client libfmq
 

--- a/services/camera/libcameraservice/device1/CameraHardwareInterface.cpp
+++ b/services/camera/libcameraservice/device1/CameraHardwareInterface.cpp
@@ -136,6 +136,7 @@ hardware::Return<void> CameraHardwareInterface::dataCallback(
     return hardware::Void();
 }
 
+#ifdef QTI_CAMERA_DEVICE
 hardware::Return<void> CameraHardwareInterface::QDataCallback(
         DataCallbackMsg msgType, uint32_t data, uint32_t bufferIndex,
         const vendor::qti::hardware::camera::device::V1_0::QCameraFrameMetadata& metadata) {
@@ -149,6 +150,7 @@ hardware::Return<void> CameraHardwareInterface::QDataCallback(
     sDataCb((int32_t) msgType, mHidlMemPoolMap.at(data), bufferIndex, &md, this);
     return hardware::Void();
 }
+#endif
 
 hardware::Return<void> CameraHardwareInterface::dataCallbackTimestamp(
         DataCallbackMsg msgType, uint32_t data,

--- a/services/camera/libcameraservice/device1/CameraHardwareInterface.h
+++ b/services/camera/libcameraservice/device1/CameraHardwareInterface.h
@@ -29,7 +29,9 @@
 #include <hardware/camera.h>
 
 #include <common/CameraProviderManager.h>
+#ifdef QTI_CAMERA_DEVICE
 #include <vendor/qti/hardware/camera/device/1.0/IQCameraDeviceCallback.h>
+#endif
 
 namespace android {
 
@@ -86,7 +88,11 @@ typedef void (*data_callback_timestamp_batch)(
 
 class CameraHardwareInterface :
         public virtual RefBase,
+#ifdef QTI_CAMERA_DEVICE
         public virtual vendor::qti::hardware::camera::device::V1_0::IQCameraDeviceCallback,
+#else
+        public virtual hardware::camera::device::V1_0::ICameraDeviceCallback,
+#endif
         public virtual hardware::camera::device::V1_0::ICameraDevicePreviewCallback {
 
 public:
@@ -396,10 +402,12 @@ private:
             hardware::camera::device::V1_0::DataCallbackMsg msgType,
             const hardware::hidl_vec<
                     hardware::camera::device::V1_0::HandleTimestampMessage>&) override;
+#ifdef QTI_CAMERA_DEVICE
     hardware::Return<void> QDataCallback(
             hardware::camera::device::V1_0::DataCallbackMsg msgType,
             uint32_t data, uint32_t bufferIndex,
             const vendor::qti::hardware::camera::device::V1_0::QCameraFrameMetadata& metadata) override;
+#endif
 
     /**
      * Implementation of android::hardware::camera::device::V1_0::ICameraDevicePreviewCallback


### PR DESCRIPTION
Set TARGET_USES_QTI_CAMERA_DEVICE to link and use

Change-Id: I3a82412190b8918248bdd7a1d823777debd67173